### PR TITLE
Update const_insight_metrics schema

### DIFF
--- a/workdir/openapi.yaml
+++ b/workdir/openapi.yaml
@@ -66172,7 +66172,9 @@ components:
         description:
           type: string
         example:
-          $ref: '#/components/schemas/const_insight_metrics_property_examples'
+          anyOf:
+          - $ref: '#/components/schemas/const_insight_metrics_property_examples'
+          - $ref: '#/components/schemas/const_insight_metrics_property_examples_object'
         intervals:
           $ref: '#/components/schemas/const_insight_metrics_property_intervals'
         keys:
@@ -66205,10 +66207,18 @@ components:
       - nullable: true
         type: string
       - type: boolean
+      - type: 'null'
+      - additionalProperties: true
+        type: object
     const_insight_metrics_property_examples:
       items:
         $ref: '#/components/schemas/const_insight_metrics_property_example'
       type: array
+    const_insight_metrics_property_examples_object:
+      additionalProperties:
+        $ref: '#/components/schemas/const_insight_metrics_property_examples'
+      description: Object containing named fields, each with array of example values
+      type: object
     const_insight_metrics_property_interval:
       properties:
         interval:
@@ -66247,7 +66257,9 @@ components:
       description: Property key is the duration (e.g. 1d, 1w, ...)
       type: object
     const_insight_metrics_property_scope:
-      description: 'enum: `ap`, `client`, `device`, `gateway`, `map`, `msp`, `mxcluster`, `mxedge`, `org`, `otherdevice`, `rssizone`, `sdkclient`, `site`, `switch`, `wlan`, `zone`'
+      description: 'enum: `ap`, `client`, `device`, `gateway`, `map`, `msp`, `mxcluster`,
+        `mxedge`, `org`, `otherdevice`, `rssizone`, `sdkclient`, `site`, `switch`,
+        `wlan`, `zone`'
       enum:
       - ap
       - client


### PR DESCRIPTION
  **1. Missing scope enum values**
  Added 10 missing values to `const_insight_metrics_property_scope`: 

`gateway`, `map`, `msp`, `mxcluster`, `org`, `otherdevice`, `rssizone`, `sdkclient`, `wlan`, `zone`

  **2. Support multiple example field formats**
  Extended `example` field to handle format variations returned by the API:
  - Array of primitives: `[18, null, 15]`
  - Object containing arrays: `{"avg_cpu": [45, 35, 10]}`
  - Array of objects: `[{"port_id": "ge-0/0/0", "bytes": 123}]`
  - Object of arrays of objects: `{"band_24": [{"channel": 11}]}`

  Uses `anyOf` pattern consistent with existing schemas (e.g., `additional_vlan_ids`).